### PR TITLE
Fixes Product Version not properly displaying on Splash Screen. Adds Product Version to 'About' menu in systray

### DIFF
--- a/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.SystrayShell/Ninjacrab.PersistentWindows.SystrayShell.csproj
+++ b/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.SystrayShell/Ninjacrab.PersistentWindows.SystrayShell.csproj
@@ -100,7 +100,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.SystrayShell/SystrayForm.Designer.cs
+++ b/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.SystrayShell/SystrayForm.Designer.cs
@@ -66,7 +66,7 @@ namespace Ninjacrab.PersistentWindows.SystrayShell
             // 
             this.notifyIconMain.ContextMenuStrip = this.contextMenuStripSysTray;
             this.notifyIconMain.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIconMain.Icon")));
-            this.notifyIconMain.Text = $"Persistent Windows {Application.ProductVersion}";
+            this.notifyIconMain.Text = "Persistent Windows";
             this.notifyIconMain.Visible = true;
             // 
             // contextMenuStripSysTray
@@ -141,7 +141,7 @@ namespace Ninjacrab.PersistentWindows.SystrayShell
             this.ClientSize = new System.Drawing.Size(284, 261);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "SystrayForm";
-            this.Text = $"Persistent Windows {Application.ProductVersion}";
+            this.Text = "Persistent Windows";
             this.contextMenuStripSysTray.ResumeLayout(false);
             this.ResumeLayout(false);
 

--- a/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.SystrayShell/SystrayForm.cs
+++ b/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.SystrayShell/SystrayForm.cs
@@ -13,6 +13,7 @@ namespace Ninjacrab.PersistentWindows.SystrayShell
         public SystrayForm()
         {
             InitializeComponent();
+            this.aboutToolStripMenuItem.Text = $"About ({Application.ProductVersion})";
         }
 
         private void CaptureWindowClickHandler(object sender, EventArgs e)


### PR DESCRIPTION
- Removed code that was in restricted area that can be overwritten by designer
- Added Version to About screen
- Removed orphaned project file reference
