### PR TITLE
Fix for inaccurate top level window checks

### DIFF
--- a/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.Common/PersistentWindowProcessor.cs
+++ b/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.Common/PersistentWindowProcessor.cs
@@ -848,8 +848,8 @@ namespace Ninjacrab.PersistentWindows.Common
 
         private void WinEventProc(IntPtr hWinEventHook, User32Events eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
         {
-            // only track top level windows
-            if (User32.GetParent(hwnd) != IntPtr.Zero)
+            // only track top level windows - but GetParent() isn't reliable for that check (because it can return owners)
+            if (User32.GetAncestor(hwnd, 1) != User32.GetDesktopWindow())
                 return;
 
             if (eventType == User32Events.EVENT_OBJECT_DESTROY)
@@ -1632,7 +1632,8 @@ namespace Ninjacrab.PersistentWindows.Common
 
             for (IntPtr hwnd = topMostWindow; hwnd != IntPtr.Zero; hwnd = User32.GetWindow(hwnd, 2))
             {
-                if (User32.GetParent(hwnd) != IntPtr.Zero)
+                // only track top level windows - but GetParent() isn't reliable for that check (because it can return owners)
+                if (User32.GetAncestor(hwnd, 1) != desktopWindow)
                     continue;
 
                 SystemWindow window = new SystemWindow(hwnd);

--- a/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.Common/WinApiBridge/User32.cs
+++ b/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.Common/WinApiBridge/User32.cs
@@ -292,6 +292,9 @@ namespace Ninjacrab.PersistentWindows.Common.WinApiBridge
         public const int GWL_STYLE = -16;
         public const long WS_CAPTION = 0x00C00000L;
 
+        [DllImport("user32.dll")]
+        public static extern IntPtr GetAncestor(IntPtr hWnd, uint gaFlags); // I'm too lazy to write an enum for them
+        
         #region Hooks
         [DllImport("user32.dll")]
         public static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);


### PR DESCRIPTION
This relates to issue #56, and changes how "top level" windows are detected.  Instead of relying on GetParent() which might return a non-0 owner hwnd for a top level window, pull in GetAncestor() and use that instead.  The only difference is that GetAncestor() will return the DESKTOP window handle (instead of 0) for top level windows.

I should apologize for my laziness in not writing out the enum for GetAncestor() flags.  I also typed the changes manually in github (because my visual studio is attached to TFS, not git.)  Please verify I didn't make a typo in transcribing.  It should also be tested a bit more than the 10 minutes I spent with it. ;)
