### PR TITLE
Fix `-delay_start` parameter

### DIFF
--- a/Help.md
+++ b/Help.md
@@ -7,6 +7,7 @@
   | -redirect_appdata | Use current dir instead of user appdata dir to store database file, this option allows launching multiple PW instances.
   | -prompt_session_restore | Upon resuming last session, ask user before restore window layout, this may help to reduce total restore time for remote desktop session on slow internet connection.
   | -notification=1 | Turn on balloon tip and sound notification when restoring windows
+  | -delay_start \<seconds\> | Delay application startup by specified seconds
   | -halt_restore \<seconds\> | Delay auto restore by specified seconds in case monitor fails to go to sleep due to fast off-on-off switching.
   | -redraw_desktop | redraw whole desktop windows after restore
   | -fix_zorder=1   | Turn on z-order fix for automatic restore

--- a/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.SystrayShell/Program.cs
+++ b/Ninjacrab.PersistentWindows.Solution/Ninjacrab.PersistentWindows.SystrayShell/Program.cs
@@ -57,7 +57,8 @@ namespace Ninjacrab.PersistentWindows.SystrayShell
                 }
                 else if (delay_start != 0)
                 {
-                    Thread.Sleep(Int32.Parse(arg));
+                    delay_start = 0;
+                    Thread.Sleep(Int32.Parse(arg) * 1000);
                 }
 
                 switch(arg)


### PR DESCRIPTION
Fixed two flaws that got introduced with 131756d (after the `-delay_start` parameter got removed in 5fa987a):
* `-delay_start` was reintroduced with ms instead of seconds
* if it wasn't passed as the last parameter, the application would crash or start more delayed than intended because every following argument would be parsed as another delay

Note that this fix is untested (edited online with GitHub), as I don't have an environment ready for it atm.