### PR TITLE
Grammar and readability edits for the documentation

### DIFF
--- a/Help.md
+++ b/Help.md
@@ -6,16 +6,16 @@
   | --- | --- |
   | -gui=0 | Do not display the PersistentWindows icon on the System Tray. Effectively runs PersistentWindows as a service
   | -splash=0       | No splash window at PersistentWindows startup
-  | -legacy_icon    | Switch to original icon (as in 5.49 release)
+  | -legacy_icon    | Switch to the original icon (as of 5.49 release)
   | -silent         | No splash window, no balloon tip hint, no event logging
   | -ignore_process "notepad.exe;foo" | Avoid restoring windows for the processes notepad.exe and foo
-  | -debug_process "notepad.exe;foo" | Print window positioning event logs for the processes notepad.exe and foo in event viewer
+  | -debug_process "notepad.exe;foo" | Print the window positioning event logs in Event Viewer for the processes *notepad.exe* and *foo*
   | -foreground_background_dual_position=0 | turn off dual position switching
-  | -prompt_session_restore | Ask the user before restoring the window layout upon resuming the last session. This may help to reduce the total restore time for remote desktop sessions on slow internet connections.
+  | -prompt_session_restore | Ask the user before restoring the window layout upon resuming the last session. This may help reduce the total restore time for remote desktop sessions on slow internet connections.
   | -delay_auto_capture 1.0 | Adjust the lag between window move event and auto-capture to 1.0 second, the default lag is 3~4 seconds.
-  | *-delay_auto_restore 2.5* | Adjust the lag between monitor on/off event and auto-restore to 2.5 seconds (the default lag is 1 second), in case restore is incomplete or monitor fails to go to sleep due to restore starts too early.
-  | -redraw_desktop | Redraw the whole desktop after a restore in case some window workarea is not refreshed
-  | -fix_zorder=1   | Preserve window Z-order for automatic restore. The Z-order of a window indicates the window's position in a stack of overlapping windows.
+  | *-delay_auto_restore 2.5* | Adjust the lag between monitor on/off event and auto-restore to 2.5 seconds (the default lag is 1 second). This is in case the restore is incomplete or the monitor fails to go to sleep due to the restore starting too early.
+  | -redraw_desktop | Redraw the whole desktop after a restore, in case some window workarea is not refreshed
+  | -fix_zorder=1   | Preserve the window Z-order for automatic restores. The Z-order of a window indicates the window's position in a stack of overlapping windows.
   | -fix_offscreen_window=0 | Turn off auto correction of off-screen windows
   | -fix_unminimized_window=0 | Turn off auto restore of unminimized windows. Use this switch to avoid undesirable window shifting during window activation, which comes with Event id 9999 : "restore minimized window ...." in event viewer.
   | ‑auto_restore_missing_windows=1 | When restoring from disk, restore missing windows without prompting the user
@@ -32,38 +32,44 @@
   | --- | --- |
   | Capture snapshot 0 | Double click the PersistentWindows icon
   | Restore snapshot 0 | Click the PersistentWindows icon
-  | Capture snapshot X | Double click the PersistentWindows icon,  then immediately press key X (X represents a digit [0-9] or a letter [a-z])
+  | Capture snapshot X | Double click the PersistentWindows icon, then immediately press key X (X represents a digit [0-9] or a letter [a-z])
   | Restore snapshot X | Click the PersistentWindows icon, then immediately press key X
-  | Undo the last snapshot restore | Alt + click the PersistentWindows icon
+  | Undo the last snapshot restore | Alt-click the PersistentWindows icon
 
 ### Shortcuts for capture/restore windows on disk
-  * To save a named capture to disk, Ctrl click the "Capture windows to disk" menu option, then enter a name in the pop-up dialog
-  * To restore the named capture from disk, Ctrl click the "Restore windows from disk" menu option, then enter the name of the previously saved capture in the dialog
-  * To restore capture from a different display config, Shift click "Restore windows from disk" menu.
+  * To save a named capture to disk, Ctrl-click the "Capture windows to disk" menu option, then enter a name in the pop-up dialog
+  * To restore the named capture from disk, Ctrl-click the "Restore windows from disk" menu option, then enter the name of the previously saved capture in the dialog
+  * To restore capture from a different display config, Shift-click the "Restore windows from disk" menu option.
 
 ---
-### Shortcuts to manipulate positions of one window
-* To activate Dual Position Switching which allows a window to switch between foreground and background mode of different positions and sizes, move or resize the window while pressing Ctrl key.
-  Once DPS is activated,
-    * Click the desktop window to bring the foreground window to its previous background position and z-order.
-    * Shift click the desktop window to bring the foreground window to its *second* last background position. This is useful if the previous background position is mis-captured due to invoking start menu or other popups. 
-    * Ctrl click the desktop window to bring the foreground window to its previous z-order while keeping the current location and size.
-* To cancel Dual Position Switching, move or resize the window without pressing Ctrl key.
-  * To bring a background DPS window to foreground *without* restoring to previous foreground position.
-    * press any of Ctrl/Shift/Alt key when activating the window.
-* To restore a new window to its last closing position
-  * Ctrl click the PW icon
-* To put the foreground window behind all other windows (similar to the Alt+Esc shortcut provided by Windows OS, which however does not work for windows inside a remote desktop window)
-  * Alt click the desktop window.
-  * Ctrl Alt click the PW icon if the foreground window is maximized.
-* To hide a window to notification area in taskbar
-  * press Ctrl key when click the minimize button
-* To enable/disable auto restore for non-toplevel window (such as a child or dialog window)
-  * To include a child/dialog window for auto capture/restore, move the window once using mouse
-  * To exclude a window from auto capture/restore, press Ctrl Shift keys when moving the window
+### Shortcuts to manipulate positions of a window
+* Dual Position Switching allows a window to switch between foreground and background mode of different positions and sizes
+
+  * To activate Dual Position Switching: 
+    * move or resize the window while pressing the Ctrl key.
+
+  * Dual Position Switching functionality:
+    * Click the desktop window to bring the foreground window to its previous background position and Z-order.
+    * Shift-click the desktop window to bring the foreground window to its *second* last background position. This is useful if the previous background position is mis-captured due to invoking start menu or other popups. 
+    * Ctrl-click the desktop window to bring the foreground window to its previous Z-order while keeping the current location and size.
+
+  * To cancel Dual Position Switching:
+    * move or resize the window without pressing the Ctrl key.
+  * To bring a background DPS window to foreground *without* restoring to the previous foreground position:
+    * press any of Ctrl/Shift/Alt key when activating the window
+* To restore a new window to its last closing position:
+  * Ctrl-click the PersistentWindows icon
+* To put the foreground window behind all other windows (similar to the Alt+Esc shortcut provided by the Windows OS, which, however, does not work for windows inside a remote desktop window):
+  * Alt-click the desktop window.
+  * Ctrl-Alt-click the PersistentWindows icon if the foreground window is maximized.
+* To hide a window to the notification area in the taskbar:
+  * Press the Ctrl key when clicking the minimize button
+* To enable/disable auto restore for non-toplevel windows (such as a child or dialog window):
+  * To include a child/dialog window for auto capture/restore, move the window once using the mouse
+  * To exclude a window from auto capture/restore, press the Ctrl-Shift keys when moving the window
 
 ### Other features
-* Replace the default app icon with your customized one
-  * Rename your .ico (or .png) file as `pwIcon.ico` (or `pwIcon.png`) and copy it to PW program folder or alternatively to `C:/Users/<YOUR_ID>/AppData/Local/PersistentWindows/`.
+* To replace the default app icon with your customized one:
+  * Rename your .ico (or .png) file as `pwIcon.ico` (or `pwIcon.png`) and copy it to the PersistentWindows program folder, or alternatively to `C:/Users/<YOUR_ID>/AppData/Local/PersistentWindows/`.
   * Copy another icon file to the same directory and rename it to `pwIconBusy.*`. This icon is displayed when PersistentWindows is busy restoring windows.
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ this tool and not have to worry about re-arranging when all is back to normal.
 ## Installation
 - Download the latest PersistentWindows*.zip file from the [Releases](https://github.com/kangyu-california/PersistentWindows/releases) page
 - Unzip the file into any directory.
-    * Note, the program can be run from any directory, but the program saves its data in `C:\Users\[User]\AppData\Local\PersistentWindows`
-- To automatically start PersistentWindows at user login, double-click `auto_start_pw.bat`. This will create a task in the Task Scheduler.
-    * For PersistentWindows to be able to restore windows with elevated privileges for tools like Task Manager and Event Viewer, `auto_start_pw.bat` should be run as administrator. 
-    <img src="https://github.com/kangyu-california/PersistentWindows/assets/59128756/e323086a-8373-4e8a-b439-3c7087550cb0" alt="auto_start_pw as administrator" width="400" />
+> Note: the program can be run from any directory, but the program saves its data in 
+> *C:\Users\\[User]\AppData\Local\PersistentWindows*
 
+#### To set up PersistentWindows to automatically start at user login:
+- Double-click the *auto_start_pw.bat* file to run it. This will create a task in the Task Scheduler.
+    * For PersistentWindows to be able to restore windows with elevated privileges for tools like Task Manager and Event Viewer, *auto_start_pw.bat* should be run as administrator. 
+        <img src="https://github.com/kangyu-california/PersistentWindows/assets/59128756/e323086a-8373-4e8a-b439-3c7087550cb0" alt="auto_start_pw as administrator" width="400" />
+  
 ## Usage Instructions
 - Run `PersistentWindows.exe` (preferably as administrator). Note that this app has no main window and its icon is hidden in the System Tray area on the taskbar by default.
 - To have the icon always appear on the taskbar, flip on the PersistentWindows item in the taskbar settings.
@@ -61,9 +64,9 @@ this tool and not have to worry about re-arranging when all is back to normal.
 
 ## Tips To Digest Before Reporting A Bug
 - The window Z-order can be restored in addition to the two-dimentional layout. This feature is enabled for snapshot restore only.
-- To help me diagnose a bug, please run Event Viewer, locate the "Windows Logs" -> "Application" section, then search for Event ID 9990 and 9999, and copy-paste the content of these events to the new issue report, as shown in following example
+- To help me diagnose a bug, please run Event Viewer, locate the "Windows Logs" -> "Application" section, then search for Event ID 9990 and 9999, and copy-paste the content of these events to the new issue report, as shown in the following example
   <img src="https://user-images.githubusercontent.com/59128756/190280503-a96ce57f-a6f0-4aad-9748-221bbb4f9207.png" alt="image" width="800"/>
-- If there are too many events to report, click "Filter current log" from the Action panel in event viewer, choose all 9990 and 9999 events in last hour, then click "Save Filtered Log File As", and attach the saved events file in the bug report
+- If there are too many events to report, click "Filter current log" from the Action panel in Event Viewer, choose all 9990 and 9999 events in last hour, then click "Save Filtered Log File As", and attach the saved events file in the bug report
   
   <img src="https://github.com/kangyu-california/PersistentWindows/assets/59128756/ce4ee2e7-8662-4eb5-9a49-cbe53d30f911.png" alt="image" width="500"/>
   

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ this tool and not have to worry about re-arranging when all is back to normal.
 - Keeps track of window position changes, and automatically restores the desktop layout, including the taskbar position, to the last matching monitor setup.
 - Supports remote desktop sessions with multiple display configurations.
 - Capture windows to disk: saves desktop layout captures to the hard drive in liteDB format, so that closed windows can be restored after a reboot.
-- Capture snapshot: saves desktop layout snapshots in memory (max 36 for each display configuration). The window z-order is preserved in the snapshot. This feature can be used as an alternative to virtual desktops on Windows 10.
+- Capture snapshot: saves desktop layout snapshots in memory (max 36 for each display configuration). The window Z-order is preserved in the snapshot. This feature can be used as an alternative to virtual desktops on Windows 10.
 - Auto Restore can be paused/resumed as desired.
 - Supports automatic upgrades.
 - Supports foreground and background dual position switching. 
@@ -42,7 +42,7 @@ this tool and not have to worry about re-arranging when all is back to normal.
 - PersistentWindows performs its duty by collecting following information:
   * window position
   * window size
-  * window z-order
+  * window Z-order
   * window caption text
   * window class name
   * process id and command line of the window
@@ -60,10 +60,11 @@ this tool and not have to worry about re-arranging when all is back to normal.
   <img src="https://user-images.githubusercontent.com/59128756/187988981-b2564618-2724-4e1e-a718-cd0786a4251e.png" alt="wait chain" width="500"/>
 
 ## Tips To Digest Before Reporting A Bug
-- The window z-order can be restored in addition to the two-dimentional layout. This feature is enabled for snapshot restore only.
+- The window Z-order can be restored in addition to the two-dimentional layout. This feature is enabled for snapshot restore only.
 - To help me diagnose a bug, please run Event Viewer, locate the "Windows Logs" -> "Application" section, then search for Event ID 9990 and 9999, and copy-paste the content of these events to the new issue report, as shown in following example
   <img src="https://user-images.githubusercontent.com/59128756/190280503-a96ce57f-a6f0-4aad-9748-221bbb4f9207.png" alt="image" width="800"/>
 - If there are too many events to report, click "Filter current log" from the Action panel in event viewer, choose all 9990 and 9999 events in last hour, then click "Save Filtered Log File As", and attach the saved events file in the bug report
+  
   <img src="https://github.com/kangyu-california/PersistentWindows/assets/59128756/ce4ee2e7-8662-4eb5-9a49-cbe53d30f911.png" alt="image" width="500"/>
   
 

--- a/README.md
+++ b/README.md
@@ -39,18 +39,18 @@ this tool and not have to worry about re-arranging when all is back to normal.
 - When software upgrades are available, a notice will show up in the menu.
 
 ## Privacy Statement
-- PersistentWindows performs its duty by collecting following information,
+- PersistentWindows performs its duty by collecting following information:
   * window position
   * window size
-  * window zorder
+  * window z-order
   * window caption text
   * window class name
   * process id and command line of the window
-  * key-strokes when interacting with PersistentWindows icon on taskbar
-  * Ctrl Alt Shift key strokes when click or move a window
-- The memory of key-strokes is typically less than 2 seconds
-- Window information history is kept in memory or on hard drive in LiteDB file format, waiting to be recalled by auto/manual restore
-- PersistentWindows periodically checks the github home page for software version upgrade, which can be disabled in menu
+  * key-strokes when interacting with the PersistentWindows icon on taskbar
+  * Ctrl, Alt, Shift key strokes when clicking or moving a window
+- The information of the key-strokes is typically stored for less than 2 seconds
+- Window information history is kept in memory or in the hard drive in LiteDB file format, waiting to be recalled by auto/manual restore
+- PersistentWindows periodically checks the github repository for software version upgrades. This can be disabled in the options menu.
   
 ## Known Issues
 - **Multiple invocations of "Restore windows from disk" might be needed in order to recover all missing windows after system startup.**
@@ -63,8 +63,8 @@ this tool and not have to worry about re-arranging when all is back to normal.
 - The window z-order can be restored in addition to the two-dimentional layout. This feature is enabled for snapshot restore only.
 - To help me diagnose a bug, please run Event Viewer, locate the "Windows Logs" -> "Application" section, then search for Event ID 9990 and 9999, and copy-paste the content of these events to the new issue report, as shown in following example
   <img src="https://user-images.githubusercontent.com/59128756/190280503-a96ce57f-a6f0-4aad-9748-221bbb4f9207.png" alt="image" width="800"/>
-- If there are too many events to report, click "Filter current log" from the Action panel in event viewer, choose all 9990,9999 events in last hour, then click "Save Filtered Log File As", and attach the saved events file in bug report
-  <img src="https://github.com/kangyu-california/PersistentWindows/assets/59128756/ce4ee2e7-8662-4eb5-9a49-cbe53d30f911.png" alt="image" width="600"/> 
+- If there are too many events to report, click "Filter current log" from the Action panel in event viewer, choose all 9990 and 9999 events in last hour, then click "Save Filtered Log File As", and attach the saved events file in the bug report
+  <img src="https://github.com/kangyu-california/PersistentWindows/assets/59128756/ce4ee2e7-8662-4eb5-9a49-cbe53d30f911.png" alt="image" width="500"/>
   
 
 

--- a/README.md
+++ b/README.md
@@ -11,32 +11,31 @@ and restores back to its previous settings.
 this tool and not have to worry about re-arranging when all is back to normal.
 
 ## Key Features
-- Keeps track of window position change, and automatically restores the desktop layout, including the taskbar position, to the last matching monitor setup.
+- Keeps track of window position changes, and automatically restores the desktop layout, including the taskbar position, to the last matching monitor setup.
 - Supports remote desktop sessions with multiple display configurations.
 - Capture windows to disk: saves desktop layout captures to the hard drive in liteDB format, so that closed windows can be restored after a reboot.
 - Capture snapshot: saves desktop layout snapshots in memory (max 36 for each display configuration). The window z-order is preserved in the snapshot. This feature can be used as an alternative to virtual desktops on Windows 10.
 - Auto Restore can be paused/resumed as desired.
 - Supports automatic upgrades.
-- Support foreground/background dual position switching. For more Features and Commands, take a look at the [Quick Help page](https://www.github.com/kangyu-california/PersistentWindows/blob/master/Help.md)
+- Supports foreground and background dual position switching. 
+- For more Features and Commands, take a look at the [Quick Help page](https://www.github.com/kangyu-california/PersistentWindows/blob/master/Help.md)
 
 ## Installation
 - Download the latest PersistentWindows*.zip file from the [Releases](https://github.com/kangyu-california/PersistentWindows/releases) page
 - Unzip the file into any directory.
     * Note, the program can be run from any directory, but the program saves its data in `C:\Users\[User]\AppData\Local\PersistentWindows`
-- Double click auto_start_pw.bat to create a task in Task Scheduler to automatically start PersistentWindows when the current user login.
-- It is highly recommended to run auto_start_pw.bat as administrator in order to restore windows with elevated privilege (such as Task Manager, Event Viewer etc).
-  
-   ![image](https://github.com/kangyu-california/PersistentWindows/assets/59128756/e323086a-8373-4e8a-b439-3c7087550cb0)
-
+- To automatically start PersistentWindows at user login, double-click `auto_start_pw.bat`. This will create a task in the Task Scheduler.
+    * For PersistentWindows to be able to restore windows with elevated privileges for tools like Task Manager and Event Viewer, `auto_start_pw.bat` should be run as administrator. 
+    <img src="https://github.com/kangyu-california/PersistentWindows/assets/59128756/e323086a-8373-4e8a-b439-3c7087550cb0" alt="auto_start_pw as administrator" width="400" />
 
 ## Usage Instructions
-- Run PersistentWindows.exe (preferably as administrator). This app has no main window and its icon is hidden in the System Tray area on the taskbar by default.
+- Run `PersistentWindows.exe` (preferably as administrator). Note that this app has no main window and its icon is hidden in the System Tray area on the taskbar by default.
 - To have the icon always appear on the taskbar, flip on the PersistentWindows item in the taskbar settings.
   <img src="showicon.png" alt="taskbar setting" width="400" />
-- Right click the icon to show the menu, where the capture and restore actions can be selected.
+- Right click the PersistentWindows icon to show the menu, where the capture and restore actions can be selected.
   ![image](https://github.com/kangyu-california/PersistentWindows/assets/59128756/6a196d75-7d86-4bd3-8873-4a4d65cb3c30)
 
-- To restore taskbar position, avoid moving mouse when the icon turns red.
+- To restore the taskbar position, avoid moving mouse when the icon turns red.
 - When software upgrades are available, a notice will show up in the menu.
 
 ## Privacy Statement

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # PersistentWindows
-The code is forked from [ninjacrab.com/persistent-windows](http://www.ninjacrab.com/persistent-windows/) to fix a long-standing [issue](https://answers.microsoft.com/en-us/windows/forum/windows_10-hardware/windows-10-multiple-display-windows-are-moved-and/2b9d5a18-45cc-4c50-b16e-fd95dbf27ff3?page=1&auth=1) on Windows 7/10/11 where windows get repositioned upon computer system waking up, laptop switching external display, monitor resolution changing (such as exit from full screen gaming) or RDP reconnecting.
+This project addresses a long-standing [issue](https://answers.microsoft.com/en-us/windows/forum/windows_10-hardware/windows-10-multiple-display-windows-are-moved-and/2b9d5a18-45cc-4c50-b16e-fd95dbf27ff3?page=1&auth=1) in Windows 7, 10, and 11, where windows get repositioned after events such as the system waking up, external monitor connections or disconnections, changes in monitor resolution (e.g., exiting full-screen gaming), or during RDP reconnections. The code was forked from [ninjacrab.com/persistent-windows](http://www.ninjacrab.com/persistent-windows/).
+
 ## Original Description
 > What is PersistentWindows?
 >


### PR DESCRIPTION
in commit 710077c, for the "Shortcuts to manipulate positions of a window" in the help.md page: 
I'm not too familiar with those shortcuts and what Dual Position Switching is. But as I understand it, some of those shortcuts are part of DPS, and some are general shortcuts not specific to DPS. So I tried to group the DPS ones together. So please pay attention to the indentation levels I added and see if that make sense