### PR TITLE
Fix Alt+Tab lag from synchronous WM_GETTEXT and VirtualDesktop COM probe

### DIFF
--- a/Ninjacrab.PersistentWindows.Solution/Common/PersistentWindowProcessor.cs
+++ b/Ninjacrab.PersistentWindows.Solution/Common/PersistentWindowProcessor.cs
@@ -1377,26 +1377,27 @@ namespace PersistentWindows.Common
             if (use_cache && windowTitle.ContainsKey(hwnd))
                 return windowTitle[hwnd];
 
+            string result = "";
             try
             {
-                var length = User32.GetWindowTextLength(hwnd);
-                if (length > 0)
-                {
-                    length++;
-                    var title = new StringBuilder(length);
-                    User32.GetWindowText(hwnd, title, length);
-                    var t = title.ToString();
-                    t = t.Trim();
-                    return t;
-                }
+                // InternalGetWindowText reads from win32k cache — never blocks on target's UI thread,
+                // unlike GetWindowText which sends WM_GETTEXT cross-process.
+                const int bufSize = 512;
+                var title = new StringBuilder(bufSize);
+                int chars = User32.InternalGetWindowText(hwnd, title, bufSize);
+                if (chars > 0)
+                    result = title.ToString().Trim();
             }
             catch (Exception)
             {
-
             }
 
-            //return hwnd.ToString("X8");
-            return "";
+            // populate cache even for empty results so repeated WinEvents on the same hwnd
+            // do not re-query (this dictionary is cleared in EVENT_OBJECT_DESTROY)
+            if (use_cache)
+                windowTitle[hwnd] = result;
+
+            return result;
         }
 
         private static bool IsMinimized(IntPtr hwnd)
@@ -2425,9 +2426,15 @@ namespace PersistentWindows.Common
 
                         case User32Events.EVENT_SYSTEM_FOREGROUND:
                             {
-                                var cur_vdi = VirtualDesktop.GetWindowDesktopId(hwnd);
-                                if (cur_vdi != Guid.Empty)
-                                    curVirtualDesktop = cur_vdi;
+                                // VirtualDesktop.GetWindowDesktopId is a COM call that can stall during Alt+Tab cycling.
+                                // During alt-held cycling the active virtual desktop cannot change, so skip the probe;
+                                // the foregroundTimer (fires after alt release) will catch any real desktop change.
+                                if (!alt_key_pressed)
+                                {
+                                    var cur_vdi = VirtualDesktop.GetWindowDesktopId(hwnd);
+                                    if (cur_vdi != Guid.Empty)
+                                        curVirtualDesktop = cur_vdi;
+                                }
 
                                 if (restoringFromDB)
                                 {

--- a/Ninjacrab.PersistentWindows.Solution/Common/WinApiBridge/User32.cs
+++ b/Ninjacrab.PersistentWindows.Solution/Common/WinApiBridge/User32.cs
@@ -229,6 +229,10 @@ namespace PersistentWindows.Common.WinApiBridge
         [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         public static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
 
+        // Reads window title from win32k.sys cached state — no WM_GETTEXT sent, never blocks on target's UI thread.
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "InternalGetWindowText")]
+        public static extern int InternalGetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
         [DllImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool GetWindowPlacement(IntPtr hWnd, ref WindowPlacement lpwndpl);


### PR DESCRIPTION
## Summary

Alt+Tab cycling was visibly laggy — sometimes the switcher froze until Alt was released or the user clicked — whenever PersistentWindows was running. Closing PW restored normal Alt+Tab speed.

## Root cause

`WinEventProcCore` runs on the STA hook thread under `captureLock` for every WinEvent. The `EVENT_SYSTEM_FOREGROUND` path made two stalling calls per Alt+Tab cycle:

1. **`GetWindowTitle` → `User32.GetWindowText`** sends `WM_GETTEXT` cross-process, blocking on the target's UI thread (Vista+ aborts after ~5 s, but smaller stalls still accumulate). The `windowTitle` cache was populated only by capture/restore paths, so every freshly-tabbed window hit the sync path on its first foreground event.
2. **`VirtualDesktop.GetWindowDesktopId`** is a COM call that can stall when the desktop manager is busy. It fired on every foreground change — including every Alt+Tab cycle — even though the active virtual desktop cannot change while the user is mid-cycling Alt+Tab.

Combined with the WinEvent re-entrancy guard added in 9ec288e9 (which drops nested callbacks while the STA is blocked), this manifested as sluggish cycling and occasional fully-stuck switcher frames.

## Fix

- Use **`InternalGetWindowText`** (undocumented but stable since NT 3.51 — used by Explorer's own Alt+Tab switcher, Task Manager, Spy++). It reads the title from `win32k` cache without sending a message, so it never blocks on the target's UI thread.
- **Always populate `windowTitle[hwnd]` from `GetWindowTitle`**, including the empty-string result, so re-tabbing the same hwnd never re-queries. The cache is already cleared in `EVENT_OBJECT_DESTROY`, so stale entries cannot leak.
- **Skip `VirtualDesktop.GetWindowDesktopId`** in `EVENT_SYSTEM_FOREGROUND` while `alt_key_pressed`. The `foregroundTimer` fires after Alt release and probes the desktop then if anything actually changed.

## Test plan

- [x] Build Debug succeeds
- [x] Live-validated: cycling Alt+Tab through 10+ windows (Brave, VS Code, Explorer, Steam, plus other heavy clients) is now responsive with PW running — matches the speed observed when PW is closed
- [x] No visible regression in normal foreground tracking (window focus restore on Alt+Tab release still works)
- [x] Sanity-check on multi-virtual-desktop setup (desktop change after Alt+Tab release still detected by the timer-driven path)

## Files changed

- `Ninjacrab.PersistentWindows.Solution/Common/PersistentWindowProcessor.cs` — `GetWindowTitle` rewritten; alt-skip for VirtualDesktop probe in foreground event
- `Ninjacrab.PersistentWindows.Solution/Common/WinApiBridge/User32.cs` — P/Invoke for `InternalGetWindowText`

🤖 Generated with [Claude Code](https://claude.com/claude-code)