### PR TITLE
Skip Alt+Tab switcher and Task View overlays in WinEventProc

### DIFF
--- a/Ninjacrab.PersistentWindows.Solution/Common/PersistentWindowProcessor.cs
+++ b/Ninjacrab.PersistentWindows.Solution/Common/PersistentWindowProcessor.cs
@@ -2169,6 +2169,25 @@ namespace PersistentWindows.Common
             }
         }
 
+        // Transient shell UI windows (Alt+Tab switcher, Task View, Win10/11 XAML switcher overlay)
+        // appear briefly on every Alt+Tab and get destroyed within ~500ms. PW must never track them:
+        // capturing them takes captureLock and pollutes monitorApplications; their destroy event then
+        // re-acquires the lock and writes a "discard capture" entry to the Windows event log.
+        private static bool IsTransientShellWindow(IntPtr hwnd)
+        {
+            try
+            {
+                string cls = GetWindowClassName(hwnd);
+                return cls == "Task Switching"
+                    || cls == "MultitaskingViewFrame"
+                    || cls == "XamlExplorerHostIslandWindow";
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
         private void WinEventProcCore(IntPtr hWinEventHook, User32Events eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
         {
             if (!initialized)
@@ -2179,6 +2198,11 @@ namespace PersistentWindows.Common
 
             if (eventType != User32Events.EVENT_OBJECT_CREATE && idObject != 0)
                 // ignore non-window object (caret etc)
+                return;
+
+            // Skip Alt+Tab switcher / Task View overlays for all events except DESTROY.
+            // DESTROY is allowed through so any state recorded before this filter existed can self-clean.
+            if (eventType != User32Events.EVENT_OBJECT_DESTROY && IsTransientShellWindow(hwnd))
                 return;
 
             bool ctrl_key_pressed = (User32.GetKeyState(0x11) & 0x8000) != 0;


### PR DESCRIPTION
## Summary

Companion to #455. The Win32 Alt+Tab switcher overlay is itself a real window with class name `Task Switching` (classic switcher), `MultitaskingViewFrame` (Task View), or `XamlExplorerHostIslandWindow` (Win10/11 newer XAML overlay). PW had no class filter for these, so every Alt+Tab cycle would:

1. Receive `EVENT_OBJECT_CREATE` for the switcher → `StartCaptureTimer`
2. Capture timer fires (≥250 ms later) → `CaptureWindow` under `captureLock` → adds the switcher to `monitorApplications`
3. Switcher closes → `EVENT_OBJECT_DESTROY` → re-acquires `captureLock` for the full cleanup loop, finds the recent capture, logs `"discard capture when closing window Task Switching"` to the Application event log (a synchronous RPC to the Event Log Service)

Today's event log (under source `PersistentWindows`) showed four such "discard capture when closing window Task Switching" entries from normal Alt+Tab use. Each cycle takes `captureLock` on the STA hook thread, contending with concurrent capture/restore work and contributing to the residual sluggishness still observed after #455.

## Fix

Filter the three known transient shell UI classes at the top of `WinEventProcCore`. Skip everything except `EVENT_OBJECT_DESTROY` — DESTROY is still allowed through so any state recorded *before* this filter existed can be cleaned on first encounter.

`GetClassName` is a fast kernel-only query (no IPC, never blocks on the target's UI thread), so the filter cost is negligible.

## Files changed

- `Ninjacrab.PersistentWindows.Solution/Common/PersistentWindowProcessor.cs` — adds `IsTransientShellWindow` helper and one early-return in `WinEventProcCore`

## Relation to #455

Independent of #455 (works against `master` directly). Both PRs add complementary fixes to the same Alt+Tab hot path; can land in either order.

## Test plan

- [x] Builds Debug clean
- [x] Live-validate: under heavier real-world use, fewer `Task Switching`-related entries in the event log, smoother Alt+Tab in scenarios that previously stuttered

🤖 Generated with [Claude Code](https://claude.com/claude-code)