### PR TITLE
Preserve user-initiated captures in UndoCapture on session lock

### DIFF
--- a/Ninjacrab.PersistentWindows.Solution/Common/PersistentWindowProcessor.cs
+++ b/Ninjacrab.PersistentWindows.Solution/Common/PersistentWindowProcessor.cs
@@ -3312,6 +3312,17 @@ namespace PersistentWindows.Common
 
         private void UndoCapture(DateTime ref_time)
         {
+            // The most recent capture is preserved when it was triggered by user activity
+            // (e.g. user-initiated minimize via the minimize button, alt+space+n, or a
+            // taskbar interaction). userMovePrev reflects the userMove flag at the moment
+            // that capture cycle started — true means the capture was kicked off by a
+            // WinEvent on a window already tracked by PW, which is the user-intent signal.
+            // Without this guard, minimizing a window a second or two before pressing
+            // Win+L would have the minimize rolled back on session unlock and the window
+            // would come up un-minimized.
+            if (userMovePrev)
+                return;
+
             // rewind disqualified capture time
             if (snapshotTakenTime.ContainsKey(curDisplayKey) && snapshotTakenTime[curDisplayKey].ContainsKey(MaxSnapshots))
             {


### PR DESCRIPTION
## Summary

Minimize a window, then press Win+L within 2-3 seconds. On unlock, the window comes back **un-minimized** — the deliberate user action was silently undone.

## Root cause

`UndoCapture` fires on `SessionLock` (and on power-state changes). Its intent is to rewind a capture that landed within `CaptureLatency` (3 s) of those events, on the assumption that the OS may have transiently mutated window state as part of the lock/sleep transition and the capture should not be the restore target. It rewinds the snapshot time pointer to the prior capture.

This is too aggressive for the common pattern of minimize-then-lock. The user's minimize generates a legitimate capture, `UndoCapture` rolls it back, and the unlock restore reads the pre-minimize record.

Reproduced today on a fresh build. Event log:
```
21:50:32 Session closing: reason SessionLock
21:50:32 undo capture of <displayKey> at 21:50:29
21:54:29 Start restoring window layout back to 21:50:27   ← pre-minimize capture
21:54:33 Restore finished in pass 2 with 17 windows recovered
         → Netflix came up in the foreground
```

## Fix

PW already tracks whether the most recent capture cycle was triggered by user activity. `userMove` is set to true by `WinEventProc` on events for known windows (`EVENT_OBJECT_CREATE`, `EVENT_SYSTEM_MINIMIZEEND` / `MINIMIZESTART` / `MOVESIZEEND` on a window in `monitorApplications` or in `allUserMoveWindows`). The `CaptureApplicationsOnCurrentDisplays` loop snapshots `userMove` into `userMovePrev` right before resetting it (line 777), so `userMovePrev` reflects *"the last completed capture was user-initiated."*

`UndoCapture` now early-returns when `userMovePrev` is true, preserving the user-intent state change. OS-only transients (no associated user `WinEvent` on a tracked window) leave `userMovePrev` false and continue to be eligible for rollback as before — so the existing protection against OS noise around lock/sleep is unchanged for those cases.

## Files changed

- `Ninjacrab.PersistentWindows.Solution/Common/PersistentWindowProcessor.cs` — 11 lines in `UndoCapture`

## Test plan

- [x] Builds Debug clean
- [x] Live-validate: minimize a window, lock within 2-3 s, unlock — window should remain minimized
- [x] Existing display-change / sleep behavior unchanged (windows restored after OS-induced transients still recover correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)